### PR TITLE
fix: use 'lazyredraw' to prevent cursor jump on pairing

### DIFF
--- a/lua/ultimate-autopair/core.lua
+++ b/lua/ultimate-autopair/core.lua
@@ -121,16 +121,18 @@ local lz ---@type boolean? save `vim.go.lz`
 function M.run_run(key)
     -- Set 'lazyredraw' on paring to prevent cursor jump caused by `<C-g>U<Left>`
     -- Source: https://github.com/windwp/nvim-autopairs/pull/403
-    lz = vim.go.lz
-    vim.go.lz = true
+    if not vim.go.lz then
+        lz = vim.go.lz
+        vim.go.lz = true
 
-    vim.schedule(function()
-      if lz == nil then
-        return
-      end
-      vim.go.lz = lz
-      lz = nil
-    end)
+        vim.schedule(function()
+          if lz == nil then
+            return
+          end
+          vim.go.lz = lz
+          lz = nil
+        end)
+    end
 
     return M.funcs[key]()
 end

--- a/lua/ultimate-autopair/core.lua
+++ b/lua/ultimate-autopair/core.lua
@@ -115,9 +115,23 @@ function M.get_run(key)
     end
     return 'v:lua.'..M.global_name..'.run_run("'..vim.fn.escape(key,[[\\"]])..'")'
 end
+local lz ---@type boolean? save `vim.go.lz`
 ---@param key string
 ---@return string
 function M.run_run(key)
+    -- Set 'lazyredraw' on paring to prevent cursor jump caused by `<C-g>U<Left>`
+    -- Source: https://github.com/windwp/nvim-autopairs/pull/403
+    lz = vim.go.lz
+    vim.go.lz = true
+
+    vim.schedule(function()
+      if lz == nil then
+        return
+      end
+      vim.go.lz = lz
+      lz = nil
+    end)
+
     return M.funcs[key]()
 end
 ---@param mode string


### PR DESCRIPTION
Ultimate-autopair uses `<C-g>U<Left>` to close the pair and move the cursor left without beginning a new undo block. This makes the cursor move right and then jump back:

https://github.com/user-attachments/assets/b0eaf4b7-5529-4584-a851-22fea5fb7e43

This PR uses `:h lazyredraw` to prevent the jumps and achieve a smoother visual effect:

https://github.com/user-attachments/assets/34e6305d-176a-4ce4-90d9-7897c59ddf8c

