### PR TITLE
fix: resume &iskeyword on failure

### DIFF
--- a/lua/ultimate-autopair/extension/alpha.lua
+++ b/lua/ultimate-autopair/extension/alpha.lua
@@ -80,8 +80,9 @@ function M.check_change_iskeyword(o,m,ext,incheck)
     else
         vim.o.iskeyword=utils.ft_get_option(utils.getsmartft(o),'iskeyword')
     end
-    local ret=M.check(o,m,ext,incheck)
+    local ok,ret=pcall(M.check, o,m,ext,incheck)
     vim.o.iskeyword=savekeyword
+    if not ok then error(ret) end
     return ret
 end
 ---@param m prof.def.module


### PR DESCRIPTION
My `&iskeyword` changed unexpectedly (observed from changing of `i_CTRL-W`'s behavior).

I've been confused for a long time.

The only clue is it's set from `vim.o`:
```
  iskeyword=!-~,^*,^|,^",192-255

	Last set from ~/b/neovim/runtime/lua/vim/_options.lua line 716
```

So it's not `b:undo_plugin`, after searching all files in my rtp, here seems the only place
toggle the value, although no more clue/repro...
