### PR TITLE
fix: don't modify global &iskeyword

### DIFF
--- a/lua/ultimate-autopair/extension/alpha.lua
+++ b/lua/ultimate-autopair/extension/alpha.lua
@@ -74,14 +74,14 @@ end
 function M.check_change_iskeyword(o,m,ext,incheck)
     local conf=ext.conf
     ---@cast conf ext.alpha.conf
-    local savekeyword=vim.o.iskeyword
+    local savekeyword=vim.bo.iskeyword
     if default.orof(conf.no_ft_iskeyword,o,m,incheck) then
-        vim.o.iskeyword=vim.api.nvim_get_option_value('iskeyword',{buf=vim.api.nvim_get_current_buf()})
+        vim.bo.iskeyword=vim.api.nvim_get_option_value('iskeyword',{buf=vim.api.nvim_get_current_buf()})
     else
-        vim.o.iskeyword=utils.ft_get_option(utils.getsmartft(o),'iskeyword')
+        vim.bo.iskeyword=utils.ft_get_option(utils.getsmartft(o),'iskeyword')
     end
     local ok,ret=pcall(M.check, o,m,ext,incheck)
-    vim.o.iskeyword=savekeyword
+    vim.bo.iskeyword=savekeyword
     if not ok then error(ret) end
     return ret
 end


### PR DESCRIPTION
```
When editing a new buffer, its local option values must be initialized.  Since
the local options of the current buffer might be specifically for that buffer,
these are not used.  Instead, for each buffer-local option there also is a
global value, which is used for new buffers.  With ":set" both the local and
global value is changed.  With "setlocal" only the local value is changed,
thus this value is not used when editing a new buffer.
```

`vim.o`/`:set` modify both global/local option.

So when switch to a new buffer without resetting local value
(e.g. without `setlocal isk` in its `ftplugin`), it will
our modifed version global value.

Address https://github.com/altermo/ultimate-autopair.nvim/pull/113#issuecomment-3237626071.
