### PR TITLE
fix: get_parser don't throw error in nightly

### DIFF
--- a/lua/ultimate-autopair/utils.lua
+++ b/lua/ultimate-autopair/utils.lua
@@ -137,7 +137,7 @@ function M.gettsnode(o,extend,extendpre)
         return save[tostring(linenr)..';'..tostring(col)] or nil
     end
     local s,parser=pcall(vim.treesitter.get_parser)
-    if not s then save.no_parser=true return end
+    if not s or not parser then save.no_parser=true return end
     if not save.has_parsed then
         parser:parse(true)
         save.has_parsed=true
@@ -186,7 +186,7 @@ function M.getsmartft(o,notree)
         return cache[tostring(linenr)..';'..tostring(col)] or vim.o.filetype
     end
     local s,parser=pcall(vim.treesitter.get_parser)
-    if not s then cache.no_parser=true return vim.o.filetype end
+    if not s or not parser then cache.no_parser=true return vim.o.filetype end
     if not cache.has_parsed then
         parser:parse(true)
         cache.has_parsed=true


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/37276

To reproduce, type `(` in a scratch buffer.
